### PR TITLE
Fix code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/app.py
+++ b/app.py
@@ -176,7 +176,11 @@ def changelog():
 @app.route('/analysis/<int:ticket_number>')
 def view_analysis(ticket_number):
     analysis_filename = f"analysis_{ticket_number}.txt"
-    analysis_path = os.path.join(app.config['ANALYSIS_FOLDER'], analysis_filename)
+    analysis_path = os.path.normpath(os.path.join(app.config['ANALYSIS_FOLDER'], analysis_filename))
+
+    if not analysis_path.startswith(app.config['ANALYSIS_FOLDER']):
+        flash('Ungültiger Pfad.')
+        return redirect(url_for('upload_file'))
 
     if os.path.exists(analysis_path):
         with open(analysis_path, 'r', encoding='utf-8') as f:


### PR DESCRIPTION
Fixes [https://github.com/NickleLP/CrashDumpAnalyzer/security/code-scanning/1](https://github.com/NickleLP/CrashDumpAnalyzer/security/code-scanning/1)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root folder. We can achieve this by normalizing the path using `os.path.normpath` and then checking that the normalized path starts with the root folder. This will prevent any path traversal attempts.

1. Normalize the constructed file path using `os.path.normpath`.
2. Check that the normalized path starts with the root folder (`app.config['ANALYSIS_FOLDER']`).
3. If the check fails, raise an exception or handle the error appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
