### PR TITLE
Fix code scanning alert no. 7: Uncontrolled data used in path expression

### DIFF
--- a/app.py
+++ b/app.py
@@ -195,7 +195,12 @@ def changelog():
 @app.route('/analysis/<int:ticket_number>')
 def view_analysis(ticket_number):
     analysis_filename = f"analysis_{ticket_number}.txt"
-    analysis_path = os.path.join(app.config['ANALYSIS_FOLDER'], analysis_filename)
+    base_path = app.config['ANALYSIS_FOLDER']
+    analysis_path = os.path.normpath(os.path.join(base_path, analysis_filename))
+
+    if not analysis_path.startswith(base_path):
+        flash(_('Invalid file path.'))
+        return redirect(url_for('upload_file'))
 
     if os.path.exists(analysis_path):
         with open(analysis_path, 'r', encoding='utf-8') as f:

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+## Version 1.0.4 - 01.10.2024
+
+- Security improvement: to the file path handling in the view_analysis function in app.py.
+  It ensures that the file path is normalized and checked to prevent directory traversal attacks.
+
 ## Version 1.0.3 - 30.09.2024
 
 - New language: Dutch can now be used as a language


### PR DESCRIPTION
Fixes [https://github.com/NickleLP/CrashDumpAnalyzer/security/code-scanning/7](https://github.com/NickleLP/CrashDumpAnalyzer/security/code-scanning/7)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root directory. This can be achieved by normalizing the path and verifying that it starts with the intended base directory. Additionally, we should ensure that the `ticket_number` is a valid integer to prevent any non-integer values from being used.

1. Normalize the constructed file path using `os.path.normpath`.
2. Verify that the normalized path starts with the base directory.
3. Ensure that `ticket_number` is a valid integer.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
