### PR TITLE
Fix code scanning alert no. 11: URL redirection from remote source

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,8 +24,8 @@ VALID_REDIRECTS = [
 
 def validate_url(url):
     parsed_url = urlparse(url.replace('\\', ''))
-    if parsed_url.path in VALID_REDIRECTS:
-        return url
+    if parsed_url.path in VALID_REDIRECTS and not parsed_url.query and not parsed_url.fragment:
+        return parsed_url.path
     return '/'
 
 def get_locale():

--- a/app.py
+++ b/app.py
@@ -10,18 +10,18 @@ import sys
 from urllib.parse import urlparse
 
 app = Flask(__name__)
-    parsed_url = urlparse(url.replace('\\', ''))
-    if not parsed_url.netloc and not parsed_url.scheme:
-        return url
-    return '/'
-
-app = Flask(__name__)
-app.secret_key = 'SecrectKey1234'  # Dies zu einem sicheren Wert ändern
+app.secret_key = '578493092754320oio6547a32653402tzu174321045d414d5g4d5g314d5644315¨ü6448¨$34ö14$üöäiä643*914*64*op416*43146*443*i1*643i*16*443*146*4431*464*31464i4315p453145oi6443165464531'
 app.jinja_env.add_extension('jinja2.ext.i18n')
 app.config['UPLOAD_FOLDER'] = 'uploads'
 app.config['ANALYSIS_FOLDER'] = 'analyses'
 app.config['BABEL_DEFAULT_LOCALE'] = 'en'
 app.config['BABEL_SUPPORTED_LOCALES'] = ['en', 'de', "nl"]
+
+def validate_url(url):
+    parsed_url = urlparse(url.replace('\\', ''))
+    if not parsed_url.netloc and not parsed_url.scheme:
+        return url
+    return '/'
 
 def get_locale():
     # Überprüfen, ob eine Sprache in der Session gespeichert ist

--- a/app.py
+++ b/app.py
@@ -7,7 +7,13 @@ from datetime import datetime
 from flask_babel import Babel, gettext as _
 from config import VERSION
 import sys
+from urllib.parse import urlparse
 
+app = Flask(__name__)
+    parsed_url = urlparse(url.replace('\\', ''))
+    if not parsed_url.netloc and not parsed_url.scheme:
+        return url
+    return '/'
 
 app = Flask(__name__)
 app.secret_key = 'SecrectKey1234'  # Dies zu einem sicheren Wert ändern
@@ -138,11 +144,11 @@ def upload_file():
     if request.method == 'POST':
         if 'file' not in request.files:
             flash (_('No file selected')) 
-            return redirect(request.url)
+            return redirect(validate_url(request.url))
         file = request.files['file']
         if file.filename == '':
             flash (_('No file selected'))
-            return redirect(request.url)
+            return redirect(validate_url(request.url))
         if file and file.filename.lower().endswith('.dmp'):
             # Speichern der Datei
             dump_filename = f"dump_{ticket_number}.dmp"
@@ -166,7 +172,7 @@ def upload_file():
             return redirect(url_for('upload_file'))
         else:
             flash (_('Please upload a valid .dmp file'))
-            return redirect(request.url)
+            return redirect(validate_url(request.url))
     #print(f"Aktuelle Sprache in der Ansicht: {get_locale()}") 
     return render_template('index.html', tickets=tickets, version=VERSION, get_locale=get_locale)
 

--- a/app.py
+++ b/app.py
@@ -16,10 +16,15 @@ app.config['UPLOAD_FOLDER'] = 'uploads'
 app.config['ANALYSIS_FOLDER'] = 'analyses'
 app.config['BABEL_DEFAULT_LOCALE'] = 'en'
 app.config['BABEL_SUPPORTED_LOCALES'] = ['en', 'de', "nl"]
+VALID_REDIRECTS = [
+    '/', 
+    '/changelog', 
+    '/analysis'
+]
 
 def validate_url(url):
     parsed_url = urlparse(url.replace('\\', ''))
-    if not parsed_url.netloc and not parsed_url.scheme:
+    if parsed_url.path in VALID_REDIRECTS:
         return url
     return '/'
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,11 @@
 ## Version 1.0.4 - 01.10.2024
 
-- Security improvement: to the file path handling in the view_analysis function in app.py.
+- Security Fix: to the file path handling in the view_analysis function in app.py.
   It ensures that the file path is normalized and checked to prevent directory traversal attacks.
+- Security Fix: Added URL validation to prevent open redirect vulnerabilities.
+  - Imported `urlparse` from `urllib.parse`.
+  - Replaced the direct use of `request.url` with a validated version.
+  - Ensured that the URL does not contain an explicit host name and is a relative path.
 
 ## Version 1.0.3 - 30.09.2024
 

--- a/config.py
+++ b/config.py
@@ -1,1 +1,1 @@
-VERSION = "1.0.3"
+VERSION = "1.0.4"


### PR DESCRIPTION
Fixes [https://github.com/NickleLP/CrashDumpAnalyzer/security/code-scanning/11](https://github.com/NickleLP/CrashDumpAnalyzer/security/code-scanning/11)

To fix the problem, we need to validate the URL before redirecting. We can use the `urlparse` function from the Python standard library to ensure that the URL does not contain an explicit host name, making it a relative path. This will prevent open redirect vulnerabilities by ensuring that only safe, relative URLs are used for redirection.

1. Import the `urlparse` function from the `urllib.parse` module.
2. Replace the direct use of `request.url` with a validated version of the URL.
3. Ensure that the URL does not contain an explicit host name and is a relative path.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
