### PR TITLE
Fix code scanning alert no. 8: URL redirection from remote source

### DIFF
--- a/app.py
+++ b/app.py
@@ -28,6 +28,11 @@ def validate_url(url):
         return parsed_url.path
     return '/'
 
+def is_safe_url(target):
+    ref_url = urlparse(request.host_url)
+    test_url = urlparse(target)
+    return test_url.scheme in ('http', 'https') and ref_url.netloc == test_url.netloc
+
 def get_locale():
     # Überprüfen, ob eine Sprache in der Session gespeichert ist
     lang = session.get('lang', 'en')
@@ -39,7 +44,10 @@ babel = Babel(app, locale_selector=get_locale)
 @app.route('/set_language/<language>')
 def set_language(language):
     session['lang'] = language
-    return redirect(request.referrer or url_for('upload_file'))
+    referrer = request.referrer
+    if not referrer or not is_safe_url(referrer):
+        referrer = url_for('upload_file')
+    return redirect(referrer)
 
 # Erstellen der Verzeichnisse, falls sie nicht existieren
 os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+## Version 1.0.5 - 02.09.2024
+
+- Security Fix: URL redirection from remote source
+
+
 ## Version 1.0.4 - 01.10.2024
 
 - Security Fix: to the file path handling in the view_analysis function in app.py.

--- a/config.py
+++ b/config.py
@@ -1,1 +1,1 @@
-VERSION = "1.0.4"
+VERSION = "1.0.5"


### PR DESCRIPTION
Fixes [https://github.com/NickleLP/CrashDumpAnalyzer/security/code-scanning/8](https://github.com/NickleLP/CrashDumpAnalyzer/security/code-scanning/8)

To fix the problem, we need to validate the `request.referrer` before using it in the redirect. We can use a predefined list of valid redirects or ensure that the referrer is a relative URL without an explicit hostname. This will prevent open redirect vulnerabilities.

1. **General Fix Approach:**
   - Validate the `request.referrer` to ensure it is either in a list of allowed URLs or is a relative URL without an explicit hostname.

2. **Detailed Fix:**
   - Add a function to validate the referrer URL.
   - Use this function to check the `request.referrer` before using it in the redirect.

3. **Specific Changes:**
   - Add a function `validate_url` to check if the URL is in the list of valid redirects or is a relative URL.
   - Modify the redirect logic in the `set_language` function to use the validated referrer.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
