### PR TITLE
fix: add version display and French translations for UI settings

### DIFF
--- a/app.py
+++ b/app.py
@@ -216,7 +216,8 @@ def view_analysis(ticket_number):
         return render_template('analysis.html', 
                                ticket_number=ticket_number, 
                                analysis_content=analysis_content,
-                               ticket_timestamp=ticket_timestamp)
+                               ticket_timestamp=ticket_timestamp,
+                               version=VERSION)
     else:
         flash (_('Analysis report not found.'))
         return redirect(url_for('upload_file'))

--- a/templates/analysis.html
+++ b/templates/analysis.html
@@ -2,13 +2,14 @@
 <html lang="{{ get_locale() }}">
 <head>
     <meta charset="UTF-8">
+    <title>{{ _('Analysis') }} - CrashDumpAnalyzer</title>
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='style.css') }}">
     <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='favicon.ico') }}">
 </head>
 <body>
         <div id="overlay" class="overlay" onclick="toggleSettingsMenu()"></div>
         <!-- Einstellungen-Icon -->
-        <div class="settings-icon" onclick="toggleSettingsMenu()" onkeydown="handleSettingsIconKeydown(event)" role="button" tabindex="0" aria-label="Settings">
+        <div class="settings-icon" onclick="toggleSettingsMenu()" onkeydown="handleSettingsIconKeydown(event)" role="button" tabindex="0" aria-label="{{ _('Settings') }}">
             &#9881;
         </div>
     
@@ -21,6 +22,7 @@
                 <a href="{{ url_for('set_language', language='en') }}">{{ _('English') }}</a>
                 <a href="{{ url_for('set_language', language='de') }}">{{ _('Deutsch') }}</a>
                 <a href="{{ url_for('set_language', language='nl') }}">{{ _('Dutch') }}</a>
+                <a href="{{ url_for('set_language', language='fr') }}">{{ _('Français') }}</a>
                 <p>--------------------------------</p>
             </div>
             <!-- Theme-Umschalter -->
@@ -79,7 +81,7 @@
     <p><a href="{{ url_for('upload_file') }}">{{ _('Back to overview') }}</a></p> 
 
     <footer>
-        &copy; 2025 CrashDumpAnalyzer by NickleLP
+        &copy; 2025 CrashDumpAnalyzer by NickleLP | {{ _('Version') }} {{ version if version is defined else '' }}
     </footer>
 </body>
 </html>

--- a/templates/changelog.html
+++ b/templates/changelog.html
@@ -1,15 +1,15 @@
 <!doctype html>
-<html lang="de">
+<html lang="{{ get_locale() }}">
 <head>
   <meta charset="UTF-8">
-  <title>Changelog - CrashDumpAnalyzer</title>
+  <title>{{ _('Changelog') }} - CrashDumpAnalyzer</title>
   <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='style.css') }}">
   <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='favicon.ico') }}">
 </head>
 <body>
     <div id="overlay" class="overlay" onclick="toggleSettingsMenu()"></div>
     <!-- Einstellungen-Icon -->
-    <div class="settings-icon" onclick="toggleSettingsMenu()" onkeydown="handleSettingsIconKeydown(event)" role="button" tabindex="0" aria-label="Settings">
+    <div class="settings-icon" onclick="toggleSettingsMenu()" onkeydown="handleSettingsIconKeydown(event)" role="button" tabindex="0" aria-label="{{ _('Settings') }}">
         &#9881;
     </div>
 
@@ -22,6 +22,7 @@
             <a href="{{ url_for('set_language', language='en') }}">{{ _('English') }}</a>
             <a href="{{ url_for('set_language', language='de') }}">{{ _('Deutsch') }}</a>
             <a href="{{ url_for('set_language', language='nl') }}">{{ _('Dutch') }}</a>
+            <a href="{{ url_for('set_language', language='fr') }}">{{ _('Français') }}</a>
             <p>--------------------------------</p>
         </div>
         <!-- Theme-Umschalter -->
@@ -69,7 +70,7 @@
           }
        });
   </script>
-  <h1>Changelog</h1>
+  <h1>{{ _('Changelog') }}</h1>
   
   <div class="changelog-content">
     {{ changelog|safe }}
@@ -78,7 +79,7 @@
   <p><a href="{{ url_for('upload_file') }}">{{ _('Back to the main page') }}</a></p>
   
   <footer>
-    <p>&copy; 2025 CrashDumpAnalyzer by NickleLP | Version {{ version }}</p>
+    <p>&copy; 2025 CrashDumpAnalyzer by NickleLP | {{ _('Version') }} {{ version }}</p>
   </footer>
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,7 +9,7 @@
 <body>
     <div id="overlay" class="overlay" onclick="toggleSettingsMenu()"></div>
     <!-- Einstellungen-Icon -->
-    <div class="settings-icon" onclick="toggleSettingsMenu()" onkeydown="handleSettingsIconKeyDown(event)" role="button" tabindex="0" aria-label="Settings">
+    <div class="settings-icon" onclick="toggleSettingsMenu()" onkeydown="handleSettingsIconKeyDown(event)" role="button" tabindex="0" aria-label="{{ _('Settings') }}">
         &#9881;
     </div>
 

--- a/translations/fr/LC_MESSAGES/messages.po
+++ b/translations/fr/LC_MESSAGES/messages.po
@@ -139,3 +139,36 @@ msgstr "Supprimer les fichiers dump"
 msgid "Dump files cleared."
 msgstr "Fichiers dump supprimés."
 
+
+# New UI strings for settings and theming
+msgid "Settings"
+msgstr "Paramètres"
+
+msgid "Select language:"
+msgstr "Sélectionner la langue :"
+
+msgid "Français"
+msgstr "Français"
+
+msgid "Select theme:"
+msgstr "Sélectionner le thème :"
+
+msgid "Dark Mode"
+msgstr "Mode sombre"
+
+# Page titles / headings
+msgid "Changelog"
+msgstr "Journal des modifications"
+
+msgid "Analysis"
+msgstr "Analyse"
+
+# Additional backend messages
+msgid "File is too large. Maximum size is 200 MB."
+msgstr "Fichier trop volumineux. La taille maximale est de 200 Mo."
+
+msgid "Invalid file path."
+msgstr "Chemin de fichier invalide."
+
+msgid "Invalid CSRF token."
+msgstr "Jeton CSRF invalide."


### PR DESCRIPTION
This pull request improves internationalization and user experience by adding French language support and ensuring UI strings are translatable across the application. It also updates page titles and footer information to use localized strings and display the app version consistently.

**Internationalization and Language Support:**

* Added French language option to the language selector in both `analysis.html` and `changelog.html` templates, allowing users to switch the interface to French. [[1]](diffhunk://#diff-924d533f0c799e6e7f77688becdb1e4d92eb533b3df05bad8890b1eefdb2c9baR25) [[2]](diffhunk://#diff-eea9009ffdb57281300f74031d738e2457ad1a863652de50d085b595cdc697c5R25)
* Updated the French translation file `messages.po` to include new UI strings for settings, theming, page titles, and additional backend messages.

**UI and Accessibility Improvements:**

* Updated all settings icon `aria-label` attributes to use translatable strings for better accessibility in different languages in `analysis.html`, `changelog.html`, and `index.html`. [[1]](diffhunk://#diff-924d533f0c799e6e7f77688becdb1e4d92eb533b3df05bad8890b1eefdb2c9baR5-R12) [[2]](diffhunk://#diff-eea9009ffdb57281300f74031d738e2457ad1a863652de50d085b595cdc697c5L2-R12) [[3]](diffhunk://#diff-37a968442c22648ceb4a16069820cc5350b97e50f45f26c5442d7c036ad743d2L12-R12)

**Page Titles and Headings:**

* Changed page titles and `<h1>` headings in `analysis.html` and `changelog.html` to use localized strings, improving consistency and translation coverage. [[1]](diffhunk://#diff-924d533f0c799e6e7f77688becdb1e4d92eb533b3df05bad8890b1eefdb2c9baR5-R12) [[2]](diffhunk://#diff-eea9009ffdb57281300f74031d738e2457ad1a863652de50d085b595cdc697c5L2-R12) [[3]](diffhunk://#diff-eea9009ffdb57281300f74031d738e2457ad1a863652de50d085b595cdc697c5L72-R73)

**Footer and Version Display:**

* Updated the footer in `analysis.html` and `changelog.html` to display the localized "Version" string and ensure the app version is shown if available. [[1]](diffhunk://#diff-924d533f0c799e6e7f77688becdb1e4d92eb533b3df05bad8890b1eefdb2c9baL82-R84) [[2]](diffhunk://#diff-eea9009ffdb57281300f74031d738e2457ad1a863652de50d085b595cdc697c5L81-R82)
* Passed the `version` variable from the backend to the `analysis.html` template for dynamic version display.