### PR TITLE
feat: add clear_tickets functionality and corresponding translations

### DIFF
--- a/app.py
+++ b/app.py
@@ -245,6 +245,65 @@ def clear_dumps():
     flash(_('Dump files cleared.'))
     return redirect(url_for('upload_file'))
 
+
+@app.route('/clear_tickets', methods=['POST'])
+def clear_tickets():
+    """Delete all tickets: dump files, analysis files, and DB entries."""
+    form_token = request.form.get('csrf_token')
+    session_token = session.get('csrf_token')
+    if form_token is None or session_token is None:
+        flash(_('Invalid CSRF token.'))
+    if not form_token or not session_token or not secrets.compare_digest(session_token, form_token):
+        flash(_('Invalid CSRF token.'))
+        return redirect(url_for('upload_file'))
+
+    # Delete all dump files
+    upload_folder = app.config['UPLOAD_FOLDER']
+    try:
+        for name in os.listdir(upload_folder):
+            if name.lower().endswith('.dmp'):
+                file_path = os.path.join(upload_folder, name)
+                try:
+                    os.remove(file_path)
+                except OSError:
+                    pass
+    except FileNotFoundError:
+        pass
+
+    # Delete all analysis files
+    analysis_folder = app.config['ANALYSIS_FOLDER']
+    try:
+        for name in os.listdir(analysis_folder):
+            # Be conservative: only remove files that match our analysis naming pattern
+            if name.lower().startswith('analysis_') and name.lower().endswith('.txt'):
+                file_path = os.path.join(analysis_folder, name)
+                try:
+                    os.remove(file_path)
+                except OSError:
+                    pass
+    except FileNotFoundError:
+        pass
+
+    # Clear DB entries
+    try:
+        conn = sqlite3.connect(DB_PATH)
+        c = conn.cursor()
+        c.execute('DELETE FROM tickets')
+        conn.commit()
+        conn.close()
+    except sqlite3.Error:
+        # If DB operation fails, still proceed with what we could delete
+        pass
+
+    # Reset in-memory tickets
+    try:
+        tickets.clear()
+    except Exception:
+        pass
+
+    flash(_('All tickets and related files have been deleted.'))
+    return redirect(url_for('upload_file'))
+
     
 if __name__ == '__main__':
     if getattr(sys, 'frozen', False):

--- a/messages.pot
+++ b/messages.pot
@@ -138,3 +138,11 @@ msgstr ""
 msgid "Dump files cleared."
 msgstr ""
 
+
+#: templates/index.html:100
+msgid "Delete all tickets (files + DB)"
+msgstr ""
+
+#: app.py:???
+msgid "All tickets and related files have been deleted."
+msgstr ""

--- a/static/style.css
+++ b/static/style.css
@@ -240,6 +240,22 @@ footer {
     background-color: #d32f2f;
 }
 
+/* Admin actions container: place buttons side by side */
+.admin-actions {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+}
+
+/* Remove inner form card styling inside the admin actions container */
+.admin-actions form {
+    background: transparent;
+    border: 0;
+    box-shadow: none;
+    padding: 0;
+    margin: 0;
+}
+
 /* Stil für die Drop-Zone */
 #drop-zone {
     border: 2px dashed var(--border-color);

--- a/templates/index.html
+++ b/templates/index.html
@@ -97,6 +97,10 @@
         <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
         <button type="submit" class="btn-clear">{{ _('Clear dump files') }}</button>
     </form>
+    <form method="post" action="{{ url_for('clear_tickets') }}" class="admin-form upload-form">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+        <button type="submit" class="btn-clear">{{ _('Delete all tickets (files + DB)') }}</button>
+    </form>
 
     <h2>{{ _('Tickets') }}</h2>
     {% if tickets %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -93,14 +93,17 @@
     </form>
 
     <h2>{{ _('Administrator actions') }}</h2>
-    <form method="post" action="{{ url_for('clear_dumps') }}" class="admin-form upload-form">
-        <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
-        <button type="submit" class="btn-clear">{{ _('Clear dump files') }}</button>
-    </form>
-    <form method="post" action="{{ url_for('clear_tickets') }}" class="admin-form upload-form">
-        <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
-        <button type="submit" class="btn-clear">{{ _('Delete all tickets (files + DB)') }}</button>
-    </form>
+    <!-- One card that holds both admin actions side-by-side -->
+    <div class="admin-form admin-actions">
+        <form method="post" action="{{ url_for('clear_dumps') }}">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+            <button type="submit" class="btn-clear">{{ _('Clear dump files') }}</button>
+        </form>
+        <form method="post" action="{{ url_for('clear_tickets') }}">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+            <button type="submit" class="btn-clear">{{ _('Delete all tickets (files + DB)') }}</button>
+        </form>
+    </div>
 
     <h2>{{ _('Tickets') }}</h2>
     {% if tickets %}

--- a/translations/de/LC_MESSAGES/messages.po
+++ b/translations/de/LC_MESSAGES/messages.po
@@ -142,3 +142,10 @@ msgstr "Dump-Dateien löschen"
 msgid "Dump files cleared."
 msgstr "Dump-Dateien gelöscht."
 
+#: templates/index.html:100
+msgid "Delete all tickets (files + DB)"
+msgstr "Alle Tickets löschen (Dateien + DB)"
+
+#: app.py:???
+msgid "All tickets and related files have been deleted."
+msgstr "Alle Tickets und zugehörigen Dateien wurden gelöscht."

--- a/translations/en/LC_MESSAGES/messages.po
+++ b/translations/en/LC_MESSAGES/messages.po
@@ -140,3 +140,11 @@ msgstr "Clear dump files"
 msgid "Dump files cleared."
 msgstr "Dump files cleared."
 
+#: templates/index.html:100
+msgid "Delete all tickets (files + DB)"
+msgstr "Delete all tickets (files + DB)"
+
+#: app.py:???
+msgid "All tickets and related files have been deleted."
+msgstr "All tickets and related files have been deleted."
+

--- a/translations/fr/LC_MESSAGES/messages.po
+++ b/translations/fr/LC_MESSAGES/messages.po
@@ -172,3 +172,10 @@ msgstr "Chemin de fichier invalide."
 
 msgid "Invalid CSRF token."
 msgstr "Jeton CSRF invalide."
+
+# New admin actions
+msgid "Delete all tickets (files + DB)"
+msgstr "Supprimer tous les tickets (fichiers + BD)"
+
+msgid "All tickets and related files have been deleted."
+msgstr "Tous les tickets et les fichiers associes ont ete supprimes."

--- a/translations/nl/LC_MESSAGES/messages.po
+++ b/translations/nl/LC_MESSAGES/messages.po
@@ -139,3 +139,11 @@ msgstr "Dumpbestanden verwijderen"
 msgid "Dump files cleared."
 msgstr "Dumpbestanden verwijderd."
 
+#: templates/index.html:100
+msgid "Delete all tickets (files + DB)"
+msgstr "Alle tickets verwijderen (bestanden + DB)"
+
+#: app.py:???
+msgid "All tickets and related files have been deleted."
+msgstr "Alle tickets en gerelateerde bestanden zijn verwijderd."
+


### PR DESCRIPTION
This pull request introduces a new administrator action to delete all tickets, including associated dump files, analysis files, and database entries, from both the backend and frontend. It also adds internationalization support for the new feature in all translation files.

**New administrator action:**

* Added a new route and handler `clear_tickets` in `app.py` to delete all tickets, related files, and database entries, including CSRF protection and user feedback.
* Updated `templates/index.html` to add a new admin form and button for "Delete all tickets (files + DB)", allowing administrators to trigger the new action from the UI.

**Internationalization updates:**

* Added new message IDs and translations for "Delete all tickets (files + DB)" and "All tickets and related files have been deleted." in `messages.pot` and all supported languages (`messages.po` files for de, en, fr, nl). [[1]](diffhunk://#diff-6ff83a165575045e6911ce67172d70afeee1185670e8ca61782409dd03f351b8R141-R148) [[2]](diffhunk://#diff-7bbaceb3b8b7a78ec382ae40085e5ceded5173447987067b676afaacce2560c2R145-R151) [[3]](diffhunk://#diff-852046eb47f474139974edf5e69ed9758f9fde82e1432c49d772b89aef354b37R143-R150) [[4]](diffhunk://#diff-f2a7407ebc96a8e50bb2c5ad0cb0b28d9c2ecf79c47ccfaff5ac6ff1a00bb54fR175-R181) [[5]](diffhunk://#diff-bd9bb2347b8b4a7993a31f3a964754fc81173ebd05417d4e85b2264845dce03aR142-R149)