### PR TITLE
Potential fix for code scanning alert no. 19: URL redirection from remote source

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Jean-Luc Tcharnetsky
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/app.py
+++ b/app.py
@@ -41,9 +41,31 @@ def validate_url(url):
     return '/'
 
 def is_safe_url(target):
+    """
+    Validate that the target URL is safe to redirect to.
+
+    A URL is considered safe if it:
+    - Uses http/https when a scheme is present, and
+    - Has no netloc (relative URL) or the same netloc as the current request.
+    Backslashes are stripped to avoid browser-specific interpretations.
+    """
+    if not target:
+        return False
+    # Normalize backslashes to avoid bypasses like "https:\\evil.com"
+    target = target.replace('\\', '')
     ref_url = urlparse(request.host_url)
     test_url = urlparse(target)
-    return test_url.scheme in ('http', 'https') and ref_url.netloc == test_url.netloc
+
+    # If a scheme is present, it must be http or https
+    if test_url.scheme and test_url.scheme not in ('http', 'https'):
+        return False
+
+    # If netloc is present, it must match the current host
+    if test_url.netloc and test_url.netloc != ref_url.netloc:
+        return False
+
+    # Relative URLs (no scheme, no netloc) are allowed
+    return True
 
 def get_csrf_token():
     token = session.get('csrf_token')


### PR DESCRIPTION
Potential fix for [https://github.com/Jean-LucTch/CrashDumpAnalyzer/security/code-scanning/19](https://github.com/Jean-LucTch/CrashDumpAnalyzer/security/code-scanning/19)

In general, the fix is to ensure that any URL used as a redirect target, even when coming from `request.referrer`, is validated/normalized before passing it to `redirect`. The safest approaches are: (1) only allow redirects to a small set of known-good internal paths, or (2) ensure the URL is same-origin, uses an allowed scheme, and is not using tricks like backslashes or schemeless forms that browsers will interpret as external URLs.

For this codebase, the best low-impact fix is to improve `is_safe_url` to robustly validate the `target`, mirroring the recommendations in the background: remove backslashes, reject URLs with an explicit host (non-empty `netloc`) that does not match the current host, and handle schemeless and malformed URLs correctly. Then keep using this function in `set_language` as already done. Concretely:

- Update `is_safe_url` in `app.py` (lines 43–46 region) to:
  - Strip backslashes from `target`.
  - Parse using `urlparse`.
  - If a scheme is present, require it to be `http` or `https`.
  - If a network location (`netloc`) is present, require it to match the current host (`ref_url.netloc` from `request.host_url`).
  - For relative URLs (no scheme, no netloc), treat them as safe.
- Use the normalized target (with backslashes removed) for the safety check; this ensures that encoded backslash tricks cannot bypass validation.
- Leave the rest of `set_language` logic intact: if there is no referrer or it is not safe according to the improved `is_safe_url`, fall back to `url_for('upload_file')`.

No new imports are needed because `urlparse` and `request` are already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
