### PR TITLE
feat: add platform name extraction to system info in dump analyzer

### DIFF
--- a/dump_analyzer.py
+++ b/dump_analyzer.py
@@ -347,18 +347,51 @@ def extract_modules(dump_data):
         return []
 
 
+def get_platform_name(platform_id):
+    """Return a readable OS/platform name based on the minidump platform id."""
+    platform_map = {
+        0: 'Windows (Win32s)',
+        1: 'Windows (Windows 9x)',
+        2: 'Windows (NT)',
+        3: 'Windows (CE)',
+        0x8000: 'Unix',
+        0x8101: 'macOS',
+        0x8102: 'iOS',
+        0x8201: 'Linux',
+        0x8202: 'Solaris',
+        0x8203: 'Android',
+        0x8204: 'NaCl',
+        0x8205: 'PlayStation 3',
+        0x8206: 'AIX',
+        0x8207: 'Haiku',
+        0x8208: 'Minix',
+        0x8209: 'OpenBSD',
+    }
+    if platform_id in platform_map:
+        return platform_map[platform_id]
+    if platform_id < 0x8000:
+        return f"Windows (platform 0x{platform_id:X})"
+    return f"Unix-like (platform 0x{platform_id:X})"
+
+
 def extract_system_info(dump_data):
     """Extract system information from minidump data"""
     try:
         streams = parse_minidump_streams(dump_data)
         if 7 in streams:
             rva = streams[7]['rva']
+            size = streams[7].get('size', 0)
+            # Need at least up to PlatformId (offset 20) inclusive
+            if rva + 24 > len(dump_data) or size < 24:
+                return {}
             arch_val = struct.unpack_from('<H', dump_data, rva)[0]
             arch_map = {0: 'X86', 5: 'ARM', 6: 'IA64', 9: 'X64', 12: 'ARM64'}
             major = struct.unpack_from('<I', dump_data, rva + 8)[0]
             minor = struct.unpack_from('<I', dump_data, rva + 12)[0]
             build = struct.unpack_from('<I', dump_data, rva + 16)[0]
+            platform_id = struct.unpack_from('<I', dump_data, rva + 20)[0]
             return {
+                'operating_system': get_platform_name(platform_id),
                 'os_version': f"{major}.{minor}.{build}",
                 'architecture': arch_map.get(arch_val, 'UNKNOWN')
             }

--- a/tests/test_dump_analyzer.py
+++ b/tests/test_dump_analyzer.py
@@ -2,6 +2,7 @@ import builtins
 import sys
 import types
 import os
+import struct
 
 import pytest
 
@@ -71,3 +72,34 @@ def test_analyze_dump_with_cdb(analyzer_module, monkeypatch, tmp_path):
     exe_name, crash_reason = analyzer_module.analyze_dump(str(fake_dump_path), 1, str(tmp_path))
     assert exe_name == 'test.exe'
     assert '0xC0000005' in crash_reason
+
+
+def _build_minidump_with_system_info(platform_id):
+    """Create a minimal minidump byte sequence containing a SYSTEM_INFO stream."""
+    header_size = 32
+    dir_rva = header_size
+    sysinfo_rva = dir_rva + 12
+    sysinfo_size = 24  # Enough to include platform id
+    total_size = sysinfo_rva + sysinfo_size
+    dump_data = bytearray(total_size)
+
+    struct.pack_into('<IIIIIIQ', dump_data, 0, 0x504D444D, 0, 1, dir_rva, 0, 0, 0)
+    struct.pack_into('<III', dump_data, dir_rva, 7, sysinfo_size, sysinfo_rva)
+    struct.pack_into('<H', dump_data, sysinfo_rva, 9)  # Architecture X64
+    struct.pack_into('<I', dump_data, sysinfo_rva + 8, 10)  # Major version
+    struct.pack_into('<I', dump_data, sysinfo_rva + 12, 0)  # Minor version
+    struct.pack_into('<I', dump_data, sysinfo_rva + 16, 19045)  # Build number
+    struct.pack_into('<I', dump_data, sysinfo_rva + 20, platform_id)
+    return bytes(dump_data)
+
+
+@pytest.mark.parametrize("platform_id, expected_os", [
+    (2, 'Windows (NT)'),
+    (0x8201, 'Linux'),
+])
+def test_extract_system_info_includes_platform(analyzer_module, platform_id, expected_os):
+    dump_data = _build_minidump_with_system_info(platform_id)
+    info = analyzer_module.extract_system_info(dump_data)
+    assert info['operating_system'] == expected_os
+    assert info['os_version'] == '10.0.19045'
+    assert info['architecture'] == 'X64'


### PR DESCRIPTION
This pull request enhances the minidump analysis capabilities by improving how operating system/platform information is extracted and reported from minidump files. It introduces a mapping from platform IDs to human-readable names and ensures this information is included in the extracted system info. Additionally, new tests are added to verify correct platform extraction.

**Minidump system info extraction improvements:**

* Added a `get_platform_name` function in `dump_analyzer.py` to map platform IDs to readable OS/platform names, supporting a wide range of platforms.
* Updated `extract_system_info` in `dump_analyzer.py` to extract and include the human-readable `operating_system` field using the new mapping.

**Testing enhancements:**

* Added a helper function `_build_minidump_with_system_info` in `tests/test_dump_analyzer.py` to generate synthetic minidump data with specific platform IDs for testing.
* Introduced a parameterized test `test_extract_system_info_includes_platform` to verify that the correct OS name, version, and architecture are extracted for various platform IDs.
* Included a missing import of `struct` in the test file to support the new test utilities.